### PR TITLE
弾の強化に上限を設定した。プレイヤーを本体と武器に分けた。弾を武器から出すようにした。プレイヤーのHPが減るたびに武器のモデルを変更するよ…

### DIFF
--- a/DirectX/BaseEnemy.h
+++ b/DirectX/BaseEnemy.h
@@ -23,9 +23,12 @@ public:
 	/// <summary>
 	/// 初期化
 	/// </summary>
-	/// <param name="texNumber">テクスチャ番号</param>
+	/// <param name="enemyModel">モデル</param>
+	/// <param name="stayPointModel">停止座標モデル</param>
+	/// <param name="spawnPosition">スポーン時の座標</param>
+	/// <param name="stayPosition">停止座標</param>
 	/// <returns>成否</returns>
-	virtual bool Initialize(Model *model, XMFLOAT3 position) = 0;
+	virtual bool Initialize(Model *enemyModel, Model *stayPointModel, XMFLOAT3 spawnPosition, XMFLOAT3 stayPosition) = 0;
 
 	/// <summary>
 	/// 毎フレーム処理
@@ -96,8 +99,14 @@ protected:
 	void Escape();
 
 protected:
-	//敵スプライト
+	//敵オブジェクト
 	Object3d *enemyObject = nullptr;
+	//停止座標オブジェクト
+	Object3d *stayPointObject = nullptr;
+	//スポーン時座標
+	XMFLOAT3 spawnPosition = { 0, 0, 0 };
+	//移動後の座標
+	XMFLOAT3 stayPosition = { 0, 0, 0 };
 	//体力
 	int HP = 20;
 	//生きているか

--- a/DirectX/Collision.cpp
+++ b/DirectX/Collision.cpp
@@ -6,9 +6,9 @@ bool Collision::CheckCircle2Circle(DirectX::XMFLOAT3 pos1, float radius1, Direct
 {
 	float disX = pos2.x - pos1.x;
 	float disY = pos2.y - pos1.y;
-	float d = sqrtf(disX * disX + disY * disY);
+	float d = disX * disX + disY * disY;
 	float r = radius1 + radius2;
-	return d < r;
+	return d < r * r;
 }
 
 bool Collision::CheckCircle2Line(DirectX::XMFLOAT3 circlePos, float circleRadius, DirectX::XMFLOAT3 lineStartPoint, DirectX::XMFLOAT3 lineEndPoint)
@@ -46,10 +46,10 @@ bool Collision::CheckCircle2Line(DirectX::XMFLOAT3 circlePos, float circleRadius
 	//上の条件から漏れた場合、円は線分上にはないので、
 	//始点から円の中心の長さか、終点から円の中心の長さが
 	//円の半径よりも短かったら当たり
-	float start_center_length = sqrtf(start_center.x * start_center.x + start_center.y * start_center.y);
-	float end_center_length = sqrtf(end_center.x * end_center.x + end_center.y * end_center.y);
-	if (start_center_length < circleRadius ||
-		end_center_length < circleRadius)
+	float start_center_length = start_center.x * start_center.x + start_center.y * start_center.y;
+	float end_center_length = end_center.x * end_center.x + end_center.y * end_center.y;
+	float r = circleRadius * circleRadius;
+	if (start_center_length < r || end_center_length < r)
 	{
 		return true;
 	}

--- a/DirectX/GameScene.cpp
+++ b/DirectX/GameScene.cpp
@@ -92,6 +92,8 @@ void GameScene::Initialize(Camera *camera)
 	eBullModel = Model::CreateFromOBJ("enemybullet");//敵の弾のモデル
 	deadEnemyModel = Model::CreateFromOBJ("desenemy");//死んだ敵のモデル
 
+	//プレイヤーウエポンのモデルをセット
+	Player::SetWeaponModel(pHead01Model, pHead02Model, pHead03Model);
 	//プレイヤー生成
 	player = Player::Create(pBodyModel);
 
@@ -143,26 +145,57 @@ void GameScene::Update(Camera *camera)
 
 	//プレイヤー弾発射
 	bulletShotTimer--;
-	if (input->TriggerKey(DIK_SPACE) || Xinput->TriggerButton(XInputManager::PAD_RB))
+	if (bulletShotTimer <= 0 && (input->PushKey(DIK_SPACE) || Xinput->PushButton(XInputManager::PAD_RB)))
 	{
+		//プレイヤーウエポンの座標と角度を弾も持つ
+		XMFLOAT3 pos = player->GetWeaponPosition();
+		XMFLOAT3 rota = player->GetWeaponRotation();
+
+		//弾の発射をプレイヤーウエポンの真上に設定
+		float angle = DirectX::XMConvertToRadians(rota.z + 90);
+		pos.x += 8.0f * cosf(angle);
+		pos.y += 8.0f * sinf(angle);
+
+		//左側の弾発射
 		for (int i = 0; i < playerBulletNum; i++)
 		{
 			//発射されていたら飛ばす
 			if (playerBullet[i]->GetIsAlive()) { continue; }
 
-			//プレイヤーの座標と角度を弾も持つ
-			XMFLOAT3 pos = player->GetPosition();
-			XMFLOAT3 rota = player->GetRotation();
+			//弾の発射位置を左側にずらす
+			float angle2 = DirectX::XMConvertToRadians(rota.z + 180);
+			XMFLOAT3 shotPosLeft = {};
+			shotPosLeft.x = 1.5f * cosf(angle2) + pos.x;
+			shotPosLeft.y = 1.5f * sinf(angle2) + pos.y;
 
 			//弾発射
-			playerBullet[i]->BulletStart(pos, rota);
-
-			//次の弾発射までのタイマーを初期化する
-			bulletShotTimer = 10;
+			playerBullet[i]->BulletStart(shotPosLeft, rota);
 
 			//1つ発射したらループを抜ける(一気に全ての弾を撃ってしまうため)
 			break;
 		}
+
+		//右側の弾発射
+		for (int i = 0; i < playerBulletNum; i++)
+		{
+			//発射されていたら飛ばす
+			if (playerBullet[i]->GetIsAlive()) { continue; }
+
+			//弾の発射位置を右側にずらす
+			float angle2 = DirectX::XMConvertToRadians(rota.z);
+			XMFLOAT3 shotPosRight = {};
+			shotPosRight.x = 1.5f * cosf(angle2) + pos.x;
+			shotPosRight.y = 1.5f * sinf(angle2) + pos.y;
+
+			//弾発射
+			playerBullet[i]->BulletStart(shotPosRight, rota);
+
+			//1つ発射したらループを抜ける(一気に全ての弾を撃ってしまうため)
+			break;
+		}
+
+		//次の弾発射までのタイマーを初期化する
+		bulletShotTimer = 10;
 	}
 
 	//プレイヤー弾更新
@@ -427,16 +460,16 @@ void GameScene::Update(Camera *camera)
 	if (player->GetIsAlive()) { DebugText::GetInstance()->Print("PLAYER ALIVE", 100, 550); }
 	else { DebugText::GetInstance()->Print("PLAYER DEAD", 100, 550); }
 
-	if (enemys.size() == 0) { DebugText::GetInstance()->Print("ENEMY : 0", 100, 600); }
-	else if (enemys.size() == 1) { DebugText::GetInstance()->Print("ENEMY : 1", 100, 600); }
-	else if (enemys.size() == 2) { DebugText::GetInstance()->Print("ENEMY : 2", 100, 600); }
-	else if (enemys.size() == 3) { DebugText::GetInstance()->Print("ENEMY : 3", 100, 600); }
-	else if (enemys.size() == 4) { DebugText::GetInstance()->Print("ENEMY : 4", 100, 600); }
-	else if (enemys.size() == 5) { DebugText::GetInstance()->Print("ENEMY : 5", 100, 600); }
-	else if (enemys.size() == 6) { DebugText::GetInstance()->Print("ENEMY : 6", 100, 600); }
-	else if (enemys.size() == 7) { DebugText::GetInstance()->Print("ENEMY : 7", 100, 600); }
-	else if (enemys.size() == 8) { DebugText::GetInstance()->Print("ENEMY : 8", 100, 600); }
-	else if (enemys.size() == 9) { DebugText::GetInstance()->Print("ENEMY : 9", 100, 600); }
+	if (playerBullet[0]->GetPower() == 10) { DebugText::GetInstance()->Print("POWER : 10", 100, 600); }
+	else if (playerBullet[0]->GetPower() == 12) { DebugText::GetInstance()->Print("POWER : 12", 100, 600); }
+	else if (playerBullet[0]->GetPower() == 14) { DebugText::GetInstance()->Print("POWER : 14", 100, 600); }
+	else if (playerBullet[0]->GetPower() == 16) { DebugText::GetInstance()->Print("POWER : 16", 100, 600); }
+	else if (playerBullet[0]->GetPower() == 18) { DebugText::GetInstance()->Print("POWER : 18", 100, 600); }
+	else if (playerBullet[0]->GetPower() == 20) { DebugText::GetInstance()->Print("POWER : 20", 100, 600); }
+	else if (playerBullet[0]->GetPower() == 22) { DebugText::GetInstance()->Print("POWER : 22", 100, 600); }
+	else if (playerBullet[0]->GetPower() == 24) { DebugText::GetInstance()->Print("POWER : 24", 100, 600); }
+	else if (playerBullet[0]->GetPower() == 26) { DebugText::GetInstance()->Print("POWER : 26", 100, 600); }
+	else if (playerBullet[0]->GetPower() == 28) { DebugText::GetInstance()->Print("POWER : 28", 100, 600); }
 
 	DebugText::GetInstance()->Print("LSTICK:PlayerMove", 1000, 100);
 	DebugText::GetInstance()->Print("LB:Sneak", 1000, 150);
@@ -515,46 +548,26 @@ void GameScene::Draw(ID3D12GraphicsCommandList *cmdList)
 
 void GameScene::SpawnEnemy()
 {
-	////20%の確率でガルタタ　80%の確率でガルタを生成
-	//int spawnRand = rand() % 2;
+	//生成時にスポーン座標と移動後の座標を決める
+	XMFLOAT3 spawnPos = {};
+	XMFLOAT3 stayPos = {};
 
-	//if (spawnRand == 0)
-	//{
-	//	enemys.push_back(Garuta::Create(enemy01Model, { -10, -10, 0 }));
-	//	enemys.push_back(Garuta::Create(enemy01Model, { -10, 10, 0 }));
-	//	enemys.push_back(Garuta::Create(enemy01Model, { 10, -10, 0 }));
-	//	enemys.push_back(Garutata::Create(enemy01Model, { 10, 10, 0 }));
-	//}
-	//else if (spawnRand == 1)
-	//{
-	//	enemys.push_back(Garuta::Create(enemy01Model, { -20, -20, 0 }));
-	//	enemys.push_back(Garuta::Create(enemy01Model, { -20, 20, 0 }));
-	//	enemys.push_back(Garuta::Create(enemy01Model, { 20, -20, 0 }));
-	//	enemys.push_back(Garutata::Create(enemy01Model, { 20, 20, 0 }));
-	//}
+	spawnPos.x = (float)(rand() % 200 - 100);
+	spawnPos.y = 100;
 
-	//生成時に初期座標と移動方向を決める
-	XMFLOAT3 startPos = {};
+	stayPos.x = (float)(rand() % 200 - 100);
+	stayPos.y = (float)(rand() % 120 - 60);
 
-	startPos.x = (float)(rand() % 200 - 100);
-	startPos.y = (float)(rand() % 120 - 60);
-
-	////4パターンのランダムで初期座標と移動方向をセット
-	//int posAngleRand = rand() % 4;
-	//if (posAngleRand == 0) { startPos = { 0, -65, 0 }; }
-	//else if (posAngleRand == 1) { startPos = { 115, 0, 0 }; }
-	//else if (posAngleRand == 2) { startPos = { 0, 65, 0 }; }
-	//else if (posAngleRand == 3) { startPos = { -115, 0, 0 }; }
 
 	//20%の確率でガルタタ　80%の確率でガルタを生成
 	int enemyKindRand = rand() % 5;
 	if (enemyKindRand == 0)
 	{
-		enemys.push_back(Garutata::Create(enemy02Model, startPos));
+		enemys.push_back(Garutata::Create(enemy02Model, enemy02Model, spawnPos, stayPos));
 	}
 	else
 	{
-		enemys.push_back(Garuta::Create(enemy01Model, startPos));
+		enemys.push_back(Garuta::Create(enemy01Model, enemy01Model, spawnPos, stayPos));
 	}
 }
 

--- a/DirectX/Garuta.cpp
+++ b/DirectX/Garuta.cpp
@@ -1,6 +1,6 @@
 #include "Garuta.h"
 
-Garuta *Garuta::Create(Model *model, XMFLOAT3 position)
+Garuta *Garuta::Create(Model *garutaModel, Model *stayPointModel, XMFLOAT3 spawnPosition, XMFLOAT3 stayPosition)
 {
 	//インスタンスを生成
 	Garuta *instance = new Garuta();
@@ -9,7 +9,7 @@ Garuta *Garuta::Create(Model *model, XMFLOAT3 position)
 	}
 
 	//初期化
-	if (!instance->Initialize(model, position)) {
+	if (!instance->Initialize(garutaModel, stayPointModel, spawnPosition, stayPosition)) {
 		delete instance;
 		assert(0);
 	}
@@ -17,28 +17,49 @@ Garuta *Garuta::Create(Model *model, XMFLOAT3 position)
 	return instance;
 }
 
-bool Garuta::Initialize(Model *model, XMFLOAT3 position)
+bool Garuta::Initialize(Model *enemyModel, Model *stayPointModel, XMFLOAT3 spawnPosition, XMFLOAT3 stayPosition)
 {
-	//ザコリンオブジェクト生成
+	//スポーン時の座標と移動後の座標をセット
+	this->spawnPosition = spawnPosition;
+	this->stayPosition = stayPosition;
+
+	//ガルタオブジェクト生成
 	enemyObject = Object3d::Create();
 	if (enemyObject == nullptr) {
 		return false;
 	}
 
 	//初期座標セット
-	enemyObject->SetPosition(position);
+	enemyObject->SetPosition(spawnPosition);
 	//大きさをセット
 	enemyObject->SetScale({ 1.5, 1.5, 1 });
 
 	//モデルをセット
-	if (model) {
-		enemyObject->SetModel(model);
+	if (enemyModel) {
+		enemyObject->SetModel(enemyModel);
 	}
+	//ブルームをかける
+	//enemyObject->SetBloom(true);
 
-	enemyObject->SetBloom(true);
 
-	//色を赤くする
-	//enemyObject->SetColor({ 1, 0, 0, 1 });
+	//スポーン地点オブジェクト生成
+	stayPointObject = Object3d::Create();
+	if (stayPointObject == nullptr) {
+		return false;
+	}
+	//スポーン座標セット
+	stayPointObject->SetPosition(stayPosition);
+	//大きさをセット
+	stayPointObject->SetScale({ 1.5, 1.5, 1 });
+
+	//モデルをセット
+	if (stayPointModel) {
+		stayPointObject->SetModel(stayPointModel);
+	}
+	//色を変更
+	stayPointObject->SetColor({ 0, 1, 1, 1 });
+	//停止座標オブジェクトを更新
+	stayPointObject->Update();
 
 	return true;
 }

--- a/DirectX/Garuta.h
+++ b/DirectX/Garuta.h
@@ -16,17 +16,21 @@ public:
 	/// <summary>
 	/// ガルタ生成
 	/// </summary>
-	/// <param name="model">モデル</param>
-	/// <param name="position">座標</param>
+	/// <param name="garutaModel">モデル</param>
+	/// <param name="stayPointModel">停止座標モデル</param>
+	/// <param name="spawnPosition">スポーン時座標</param>
+	/// <param name="stayPosition">停止座標</param>
 	/// <returns>ガルタ</returns>
-	static Garuta *Create(Model *model, XMFLOAT3 position);
+	static Garuta *Create(Model *garutaModel, Model *stayPointModel, XMFLOAT3 spawnPosition, XMFLOAT3 stayPosition);
 
 public:
 	/// <summary>
 	/// 初期化
 	/// </summary>
-	/// <param name="model">モデル</param>
-	/// <param name="position">座標</param>
+	/// <param name="enemyModel">モデル</param>
+	/// <param name="stayPointModel">停止座標モデル</param>
+	/// <param name="spawnPosition">スポーン時座標</param>
+	/// <param name="stayPosition">停止座標</param>
 	/// <returns>成否</returns>
-	bool Initialize(Model *model, XMFLOAT3 position) override;
+	bool Initialize(Model *enemyModel, Model *stayPointModel, XMFLOAT3 spawnPosition, XMFLOAT3 stayPosition) override;
 };

--- a/DirectX/Garutata.cpp
+++ b/DirectX/Garutata.cpp
@@ -1,6 +1,6 @@
 #include "Garutata.h"
 
-Garutata *Garutata::Create(Model *model, XMFLOAT3 position)
+Garutata *Garutata::Create(Model *garutataModel, Model *stayPointModel, XMFLOAT3 spawnPosition, XMFLOAT3 stayPosition)
 {
 	//インスタンスを生成
 	Garutata *instance = new Garutata();
@@ -9,7 +9,7 @@ Garutata *Garutata::Create(Model *model, XMFLOAT3 position)
 	}
 
 	//初期化
-	if (!instance->Initialize(model, position)) {
+	if (!instance->Initialize(garutataModel, stayPointModel, spawnPosition, stayPosition)) {
 		delete instance;
 		assert(0);
 	}
@@ -17,26 +17,47 @@ Garutata *Garutata::Create(Model *model, XMFLOAT3 position)
 	return instance;
 }
 
-bool Garutata::Initialize(Model *model, XMFLOAT3 position)
+bool Garutata::Initialize(Model *enemyModel, Model *stayPointModel, XMFLOAT3 spawnPosition, XMFLOAT3 stayPosition)
 {
-	//ザコリンオブジェクト生成
+	//スポーン時の座標と移動後の座標をセット
+	this->spawnPosition = spawnPosition;
+	this->stayPosition = stayPosition;
+
+	//ガルタタオブジェクト生成
 	enemyObject = Object3d::Create();
 	if (enemyObject == nullptr) {
 		return false;
 	}
 
 	//初期座標セット
-	enemyObject->SetPosition(position);
+	enemyObject->SetPosition(spawnPosition);
 	//大きさをセット
 	enemyObject->SetScale({ 3, 3, 1 });
 
 	//モデルをセット
-	if (model) {
-		enemyObject->SetModel(model);
+	if (enemyModel) {
+		enemyObject->SetModel(enemyModel);
 	}
 
-	//色を緑にする
-	//enemyObject->SetColor({ 0, 1, 0, 1 });
+
+	//スポーン地点オブジェクト生成
+	stayPointObject = Object3d::Create();
+	if (stayPointObject == nullptr) {
+		return false;
+	}
+	//スポーン座標セット
+	stayPointObject->SetPosition(stayPosition);
+	//大きさをセット
+	stayPointObject->SetScale({ 3, 3, 1 });
+
+	//モデルをセット
+	if (stayPointModel) {
+		stayPointObject->SetModel(stayPointModel);
+	}
+	//色を変更
+	stayPointObject->SetColor({ 0, 1, 1, 1 });
+	//停止座標オブジェクトを更新
+	stayPointObject->Update();
 
 	return true;
 }

--- a/DirectX/Garutata.h
+++ b/DirectX/Garutata.h
@@ -16,17 +16,21 @@ public:
 	/// <summary>
 	/// ガルタタ生成
 	/// </summary>
-	/// <param name="model">モデル</param>
-	/// <param name="position">座標</param>
+	/// <param name="garutataModel">モデル</param>
+	/// <param name="stayPointModel">停止座標モデル</param>
+	/// <param name="spawnPosition">スポーン時座標</param>
+	/// <param name="stayPosition">停止座標</param>
 	/// <returns>ガルタタ</returns>
-	static Garutata *Create(Model *model, XMFLOAT3 position);
+	static Garutata *Create(Model *garutataModel, Model *stayPointModel, XMFLOAT3 spawnPosition, XMFLOAT3 stayPosition);
 
 public:
 	/// <summary>
 	/// 初期化
 	/// </summary>
-	/// <param name="model">モデル</param>
-	/// <param name="position">座標</param>
+	/// <param name="enemyModel">モデル</param>
+	/// <param name="stayPointModel">停止座標モデル</param>
+	/// <param name="spawnPosition">スポーン時座標</param>
+	/// <param name="stayPosition">停止座標</param>
 	/// <returns>成否</returns>
-	bool Initialize(Model *model, XMFLOAT3 position) override;
+	bool Initialize(Model *enemyModel, Model *stayPointModel, XMFLOAT3 spawnPosition, XMFLOAT3 stayPosition) override;
 };

--- a/DirectX/Player.h
+++ b/DirectX/Player.h
@@ -22,8 +22,16 @@ public:
 	/// <param name="scale">大きさ</param>
 	/// <returns>プレイヤー</returns>
 	static Player *Create(Model *model = nullptr);
-public:
 
+	/// <summary>
+	/// ウエポンのモデルをセット
+	/// </summary>
+	/// <param name="weaponHP1Model">プレイヤーのHP1状態のモデル</param>
+	/// <param name="weaponHP2Model">プレイヤーのHP2状態のモデル</param>
+	/// <param name="weaponHP3Model">プレイヤーのHP3状態のモデル</param>
+	static void SetWeaponModel(Model *weaponHP1Model, Model *weaponHP2Model, Model *weaponHP3Model);
+
+public:
 	/// <summary>
 	/// デストラクタ
 	/// </summary>
@@ -41,7 +49,7 @@ public:
 	/// 毎フレーム処理
 	/// </summary>
 	/// <param name="effect">particleクラスのインスタンス</param>
-	void Update(StageEffect* effect);
+	void Update(StageEffect *effect);
 
 	/// <summary>
 	/// 描画
@@ -66,6 +74,8 @@ public:
 	//getter
 	XMFLOAT3 GetPosition() { return playerObject->GetPosition(); }
 	XMFLOAT3 GetRotation() { return playerObject->GetRotation(); }
+	XMFLOAT3 GetWeaponPosition() { return weaponObject->GetPosition(); }
+	XMFLOAT3 GetWeaponRotation() { return weaponObject->GetRotation(); }
 	XMFLOAT3 GetScale() { return playerObject->GetScale(); }
 	int GetHP() { return HP; }
 	bool GetIsDamege() { return isDamage; }
@@ -89,8 +99,18 @@ private:
 	void Knockback();
 
 private:
+	//プレイヤーのHP1のときのウエポンのモデル
+	static Model *weaponHP1Model;
+	//プレイヤーのHP2のときのウエポンのモデル
+	static Model *weaponHP2Model;
+	//プレイヤーのHP3のときのウエポンのモデル
+	static Model *weaponHP3Model;
+
+private:
 	//プレイヤーオブジェクト
 	Object3d *playerObject = nullptr;
+	//ウエポンオブジェクト
+	Object3d *weaponObject = nullptr;
 	//体力
 	int HP = 3;
 	//ダメージを喰らっているか

--- a/DirectX/PlayerBullet.cpp
+++ b/DirectX/PlayerBullet.cpp
@@ -104,6 +104,14 @@ void PlayerBullet::PowerUp()
 	//’e‚ÌˆĞ—Í‚ğ‹­‚­‚·‚é
 	power += 2;
 
+	//’e‚Ì‹­‚³‚ÉãŒÀ‚ğ‚Â‚¯‚é
+	const int maxPower = 20;
+	//’e‚Ì‹­‚³‚ªãŒÀ‚ğ’´‚¦‚È‚¢‚æ‚¤‚É‚·‚é
+	if (power > maxPower)
+	{
+		power = maxPower;
+	}
+
 	//¶‘¶‰Â”\ŠÔ‚ğL‚Î‚·
 	lifeTime += 10;
 }

--- a/DirectX/StageEffect.cpp
+++ b/DirectX/StageEffect.cpp
@@ -16,6 +16,7 @@ const XMFLOAT3 nullNunber = { 0,0,0 };//0‚ğ“ü‚ê‚é‚Ì•Ï”
 StageEffect::~StageEffect()
 {
 	safe_delete(playerMove);
+	safe_delete(enemeyDead1);
 }
 
 void StageEffect::Initialize()


### PR DESCRIPTION
…うにした。敵のスポーンを画面外からにした。敵の生成時に停止地点をモデルで表現するようにした。弾をツインウェイに変更した。当たり判定の改善を行った（sqrtfを使わない）。