### PR TITLE
壁のエフェクトが出ないのを解消。ダメージ状態で移動のみ可能だったのを衝撃波も発射可能に変更。衝撃波の広がる速度をUP。

### DIFF
--- a/DirectX/BaseEnemy.cpp
+++ b/DirectX/BaseEnemy.cpp
@@ -95,12 +95,15 @@ void BaseEnemy::SetKnockBack(float angle, int powerLevel, float powerMagnificati
 
 	//ノックバックタイマーを初期化
 	knockBackTimer = 0;
-
 	//移動角度変更開始速度をセット
 	changeAngleSpeed = 53 * powerMagnification;
-
 	//最後に当たった衝撃波の種類を更新
 	lastCollisionShockWave = shockWaveGroup;
+
+	//衝撃派と衝突した時の距離でを壁に与えるダメージの強さを設定
+	if (powerMagnification <= 0.5f) { damagePower = 1; }
+	else if (powerMagnification <= 0.8f) { damagePower = 2; }
+	else { damagePower = 3; }
 
 	//ノックバック状態にする
 	isKnockBack = true;
@@ -170,12 +173,14 @@ void BaseEnemy::KnockBack()
 	float easeTimer = (float)knockBackTimer / knockBackTime;
 	//ノックバック基準の速度
 	const float knockBackStartSpeed = 4.0f;
-	float knockBackSpeed = Easing::OutCubic(knockBackStartSpeed, 0, easeTimer);
+	//ノックバック中の速度をセット
+	const float knockBackEaseSpeed = Easing::OutCubic(knockBackStartSpeed, 0, easeTimer);
+	const float knockBackSpeed = knockBackEaseSpeed * knockBackPower;
 
 	//座標を更新
 	XMFLOAT3 pos = enemyObject->GetPosition();
-	pos.x += knockBackSpeed * cosf(knockBackAngle) * knockBackPower;
-	pos.y += knockBackSpeed * sinf(knockBackAngle) * knockBackPower;
+	pos.x += knockBackSpeed * cosf(knockBackAngle);
+	pos.y += knockBackSpeed * sinf(knockBackAngle);
 	//更新した座標をセット
 	enemyObject->SetPosition(pos);
 

--- a/DirectX/BaseEnemy.h
+++ b/DirectX/BaseEnemy.h
@@ -105,6 +105,7 @@ public:
 	XMFLOAT3 GetRotation() { return enemyObject->GetRotation(); }
 	XMFLOAT3 GetScale() { return enemyObject->GetScale(); }
 	float GetMoveDegree() { return moveDegree; }
+	int GetDamagePower() { return damagePower; }
 	bool GetIsKnockBack() { return isKnockBack; }
 	bool GetIsAlive() { return isAlive; }
 	bool GetIsCreateEnemy() { return isCreateEnemy; }
@@ -185,6 +186,8 @@ protected:
 	float knockBackPower = 0;
 	//ノックバックしているか
 	bool isKnockBack = false;
+	//壁に与えるダメージの強さ
+	int damagePower = 0;
 	//最後に当たった衝撃波の種類
 	int lastCollisionShockWave = 0;
 	//新たに敵を生成するか

--- a/DirectX/GameCollision.cpp
+++ b/DirectX/GameCollision.cpp
@@ -120,8 +120,8 @@ bool GameCollision::CheckWallToEnemy(WallManager* wall, BaseEnemy* enemy)
 	//敵にダメージを与える
 	enemy->Damage();
 
-	//壁にもダメージを与える
-	int damagePower = 3;
+	//壁にもダメージを与える(衝撃波を当てた時の距離で壁に与えるダメージを変更)
+	int damagePower = enemy->GetDamagePower();
 	//タイトルロゴのみダメージを上げる
 	if (enemy->GetGroup() == BaseEnemy::EnemyGroup::TitleLogo) { damagePower = 7; }
 	wall->Damage(damagePower);

--- a/DirectX/GameScene.cpp
+++ b/DirectX/GameScene.cpp
@@ -22,7 +22,7 @@ GameScene::~GameScene()
 	safe_delete(titleLogoModel);
 	safe_delete(playerModel);
 	safe_delete(waveModel);
-	safe_delete(RBModel);
+	safe_delete(XButtonModel);
 	safe_delete(chaserModel);
 	safe_delete(divisionModel);
 	safe_delete(releaserModel);
@@ -93,7 +93,7 @@ void GameScene::Initialize(Camera* camera)
 	titleLogoModel = Model::CreateFromOBJ("titleLogo");//タイトルロゴのモデル
 	playerModel = Model::CreateFromOBJ("player");//プレイヤーのモデル
 	waveModel = Model::CreateFromOBJ("wave");//衝撃波のモデル
-	RBModel = Model::CreateFromOBJ("RB");//RBのモデル
+	XButtonModel = Model::CreateFromOBJ("Xbutton");//Xボタンのモデル
 	chaserModel = Model::CreateFromOBJ("enemy1_4");//追跡敵のモデル
 	divisionModel = Model::CreateFromOBJ("enemy2_3");//分裂敵のモデル
 	releaserModel = Model::CreateFromOBJ("enemy3_2");//放出敵のモデル
@@ -157,7 +157,7 @@ void GameScene::Initialize(Camera* camera)
 	blackout = Blackout::Create(1);
 
 	//タイトルシーンUI生成
-	titleUI = TitleUI::Create(RBModel);
+	titleUI = TitleUI::Create(XButtonModel);
 	//ゲーム説明生成
 	explanation = Explanation::Create(20);
 
@@ -530,6 +530,10 @@ void GameScene::Update(Camera* camera)
 			//スタートボタンを表示しない
 			UIFrame->SetIsDrawStart(false);
 		}
+
+
+		std::string wallHP = std::to_string(wall->GetHP());
+		DebugText::GetInstance()->Print("HP : " + wallHP, 200, 200);
 	}
 
 	//ポーズシーン
@@ -749,7 +753,6 @@ void GameScene::Update(Camera* camera)
 	//エフェクトの更新
 	effects->Update(camera);
 	//背景更新
-	//buckGround->Update();
 	backGround->Update();
 	//UIを囲う枠更新
 	UIFrame->Update();
@@ -1202,8 +1205,8 @@ void GameScene::ResetGame()
 void GameScene::PlayerShockWaveStart(XMFLOAT3 pos)
 {
 	//プレイヤーが自由に動けない（ダメージ状態）なら抜ける
-	//if (!player->GetIsFreeMove()) { return; }
-	if (player->GetIsDamege()) { return; }
+	if (!player->GetIsFreeMove()) { return; }
+	//if (player->GetIsDamege()) { return; }
 
 	//発射されていたら抜ける
 	if (shockWave[0]->GetIsAlive()) { return; }
@@ -1223,8 +1226,8 @@ void GameScene::BigShockWaveStart(XMFLOAT3 pos)
 	Audio* audio = Audio::GetInstance();
 
 	//プレイヤーが自由に動けない（ダメージ状態）なら抜ける
-	//if (!player->GetIsFreeMove()) { return; }
-	if (player->GetIsDamege()) { return; }
+	if (!player->GetIsFreeMove()) { return; }
+	//if (player->GetIsDamege()) { return; }
 
 	//発射されていたら抜ける
 	if (shockWave[1]->GetIsAlive()) { return; }

--- a/DirectX/GameScene.h
+++ b/DirectX/GameScene.h
@@ -167,7 +167,7 @@ private:// メンバ変数
 	Model* titleLogoModel = nullptr;//タイトルロゴのモデル
 	Model* playerModel = nullptr;//プレイヤーのモデル
 	Model* waveModel = nullptr;//衝撃波のモデル
-	Model* RBModel = nullptr;//RBのモデル
+	Model* XButtonModel = nullptr;//Xボタンのモデル
 	Model* chaserModel = nullptr;//追跡敵のモデル
 	Model* divisionModel = nullptr;//分裂敵のモデル
 	Model* releaserModel = nullptr;//放出敵のモデル

--- a/DirectX/Player.h
+++ b/DirectX/Player.h
@@ -169,7 +169,7 @@ private:
 	//ゲーム開始時の座標に移動する時間タイマー
 	int moveStartPosTimer = 0;
 	//移動速度
-	float moveSpeed = 0.5f;
+	float moveSpeed = 0;
 	//移動角度
 	float moveDegree = 0;
 	//自由に動けるか

--- a/DirectX/ShockWave.cpp
+++ b/DirectX/ShockWave.cpp
@@ -100,34 +100,13 @@ void ShockWave::PlayerWaveStart(XMFLOAT3 position)
 	shockWaveObject->SetColor({ 0, 1, 1, 1 });
 
 	//広がる速度をセット
-	spreadSpeed = 2.0f;
+	spreadSpeed = 3.0f;
 
 	//威力を設定
 	powerLevel = 1;
 
 	//生存可能時間をセット
-	aliveTime = 20;
-
-	//衝撃波発射共通処理
-	WaveStartCommon(position);
-}
-
-void ShockWave::LitteringWaveStart(XMFLOAT3 position)
-{
-	//所属グループをポイ捨て衝撃波にする
-	group = ShockWaveGroup::LitteringWave;
-
-	//色のセット
-	shockWaveObject->SetColor({ 1, 1, 1, 1 });
-
-	//広がる速度をセット
-	spreadSpeed = 1.5f;
-
-	//威力を設定
-	powerLevel = 1;
-
-	//生存可能時間をセット
-	aliveTime = 20;
+	aliveTime = 18;
 
 	//衝撃波発射共通処理
 	WaveStartCommon(position);
@@ -221,7 +200,7 @@ void ShockWave::WaveSpread()
 		//更新した色の薄さをセット
 		XMFLOAT4 color = shockWaveObject->GetColor();
 		//色を薄くしていく
-		color.w = Easing::OutQuint(1.0f, 0.1f, colorTimer);
+		color.w = Easing::OutQuint(1.0f, 0.2f, colorTimer);
 		shockWaveObject->SetColor(color);
 	}
 

--- a/DirectX/ShockWave.h
+++ b/DirectX/ShockWave.h
@@ -64,11 +64,6 @@ public:
 	void PlayerWaveStart(XMFLOAT3 position);
 
 	/// <summary>
-	/// ƒ|ƒCÌ‚ÄÕŒ‚”g”­Ë
-	/// </summary>
-	void LitteringWaveStart(XMFLOAT3 position);
-
-	/// <summary>
 	/// ‹‘åÕŒ‚”g”­Ë
 	/// </summary>
 	/// <param name="position"></param>

--- a/DirectX/StageEffect.cpp
+++ b/DirectX/StageEffect.cpp
@@ -186,10 +186,10 @@ void StageEffect::smashUpdate()
 {
 	//300超えていたら追加しない
 	int count = smash->GetCount();
-	if (count > 300) { return; }
+	if (count > 500) { return; }
 
 	//出現時間
-	const int maxFrame = 30;
+	const int maxFrame = 20;
 	//開始カラー
 	const XMFLOAT4 startColor = { 1,1,1,1 };
 	//終了カラー
@@ -218,7 +218,7 @@ void StageEffect::smashUpdate()
 
 	//表示時間をが過ぎたパーティクルを削除
 	smashInfo.remove_if([](StageEffect::SMASH& x) {
-		return x.time >= 20;
+		return x.time >= 15;
 		}
 	);
 }


### PR DESCRIPTION
衝撃波を敵に当てた位置で、敵が壁に与えるダメージを変えるようにした。プレイヤーの操作を滑らかにした。